### PR TITLE
Use WebAssembly for HEIC conversions

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -39,7 +39,8 @@
             "styles": [
               "src/styles.scss"
             ],
-            "scripts": []
+            "scripts": [],
+            "webWorkerTsConfig": "tsconfig.worker.json"
           },
           "configurations": {
             "production": {
@@ -102,7 +103,8 @@
             "styles": [
               "src/styles.scss"
             ],
-            "scripts": []
+            "scripts": [],
+            "webWorkerTsConfig": "tsconfig.worker.json"
           }
         },
         "lint": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@xmldom/xmldom": "~0.8.2",
         "exifr": "^7.1.3",
         "heic2any": "^0.0.4",
+        "libheif-js": "^1.18.2",
         "mime": "^4.0.4",
         "rxjs": "~7.8.1",
         "tslib": "^2.8.0",
@@ -11150,6 +11151,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/libheif-js": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/libheif-js/-/libheif-js-1.18.2.tgz",
+      "integrity": "sha512-4Nk0dKhhRfVS4mECcX2jSDpNU6gcHQLneJjkGQq61N8COGtjSpSA3CI+1Q3kUYv5Vf+SwIqUtaDSdU6JO37c6w==",
+      "license": "LGPL-3.0",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/license-webpack-plugin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "@types/mime-types": "^2.1.4",
         "@xmldom/xmldom": "~0.8.2",
         "exifr": "^7.1.3",
-        "heic2any": "^0.0.4",
         "libheif-js": "^1.18.2",
         "mime": "^4.0.4",
         "rxjs": "~7.8.1",
@@ -9606,11 +9605,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/heic2any": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/heic2any/-/heic2any-0.0.4.tgz",
-      "integrity": "sha512-3lLnZiDELfabVH87htnRolZ2iehX9zwpRyGNz22GKXIu0fznlblf0/ftppXKNqS26dqFSeqfIBhAmAj/uSp0cA=="
     },
     "node_modules/hosted-git-info": {
       "version": "7.0.2",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "@types/mime-types": "^2.1.4",
     "@xmldom/xmldom": "~0.8.2",
     "exifr": "^7.1.3",
-    "heic2any": "^0.0.4",
     "libheif-js": "^1.18.2",
     "mime": "^4.0.4",
     "rxjs": "~7.8.1",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@xmldom/xmldom": "~0.8.2",
     "exifr": "^7.1.3",
     "heic2any": "^0.0.4",
+    "libheif-js": "^1.18.2",
     "mime": "^4.0.4",
     "rxjs": "~7.8.1",
     "tslib": "^2.8.0",

--- a/projects/ngx-advanced-img/package.json
+++ b/projects/ngx-advanced-img/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kbrt38/ngx-advanced-img",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "private": false,
   "license": "MIT",
   "author": "Brian Martinson <brian@brianmartinson.com> (https://brianmartinson.com/)",

--- a/projects/ngx-advanced-img/package.json
+++ b/projects/ngx-advanced-img/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kbrt38/ngx-advanced-img",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "private": false,
   "license": "MIT",
   "author": "Brian Martinson <brian@brianmartinson.com> (https://brianmartinson.com/)",

--- a/projects/ngx-advanced-img/package.json
+++ b/projects/ngx-advanced-img/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kbrt38/ngx-advanced-img",
-  "version": "2.1.8",
+  "version": "2.2.1",
   "private": false,
   "license": "MIT",
   "author": "Brian Martinson <brian@brianmartinson.com> (https://brianmartinson.com/)",
@@ -29,7 +29,7 @@
     "@angular/core": ">= 15.0.0",
     "@xmldom/xmldom": ">= 0.8.10",
     "exifr": ">= 7.1.3",
-    "heic2any": "^0.0.4",
+    "libheif-js": "^1.18.2",
     "mime": ">= 4.0.4",
     "rxjs": ">= 7.8.1"
   },

--- a/projects/ngx-advanced-img/package.json
+++ b/projects/ngx-advanced-img/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kbrt38/ngx-advanced-img",
-  "version": "2.2.7",
+  "version": "2.2.8",
   "private": false,
   "license": "MIT",
   "author": "Brian Martinson <brian@brianmartinson.com> (https://brianmartinson.com/)",

--- a/projects/ngx-advanced-img/package.json
+++ b/projects/ngx-advanced-img/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kbrt38/ngx-advanced-img",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "private": false,
   "license": "MIT",
   "author": "Brian Martinson <brian@brianmartinson.com> (https://brianmartinson.com/)",

--- a/projects/ngx-advanced-img/package.json
+++ b/projects/ngx-advanced-img/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kbrt38/ngx-advanced-img",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "private": false,
   "license": "MIT",
   "author": "Brian Martinson <brian@brianmartinson.com> (https://brianmartinson.com/)",

--- a/projects/ngx-advanced-img/package.json
+++ b/projects/ngx-advanced-img/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kbrt38/ngx-advanced-img",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "private": false,
   "license": "MIT",
   "author": "Brian Martinson <brian@brianmartinson.com> (https://brianmartinson.com/)",

--- a/projects/ngx-advanced-img/package.json
+++ b/projects/ngx-advanced-img/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kbrt38/ngx-advanced-img",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "private": false,
   "license": "MIT",
   "author": "Brian Martinson <brian@brianmartinson.com> (https://brianmartinson.com/)",

--- a/projects/ngx-advanced-img/package.json
+++ b/projects/ngx-advanced-img/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kbrt38/ngx-advanced-img",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "private": false,
   "license": "MIT",
   "author": "Brian Martinson <brian@brianmartinson.com> (https://brianmartinson.com/)",

--- a/projects/ngx-advanced-img/src/lib/classes/bitmap.ts
+++ b/projects/ngx-advanced-img/src/lib/classes/bitmap.ts
@@ -481,18 +481,9 @@ export class NgxAdvancedImgBitmap {
       return Promise.reject(new Error('No valid source provided'));
     }
 
-    // HEICs need to be converted before loading
-    let needsHEICConversion = false;
     let blobData: Blob;
     if (typeof this.src === 'string') {
-      if (this.src.startsWith('data:image/heic')) {
-        needsHEICConversion = true;
-        // convert to blob
-      }
-      
       this.src = NgxAdvancedImgBitmap.dataURItoBlob(this.src);
-    } else if (this.src.type === 'image/heic') {
-      needsHEICConversion = true;
     }
 
     blobData = this.src;
@@ -512,278 +503,277 @@ export class NgxAdvancedImgBitmap {
         this.image.crossOrigin = 'anonymous';
       }
 
-        // throw error if image has been destroyed
+      // throw error if image has been destroyed
+      if (!this.image) {
+        reject(this);
+      }
+
+      // store the blob's file size
+      this._initialFileSize = blobData.size;
+
+      // if we have an expiration clock ticking, clear it
+      if (this.expirationClock) {
+        clearTimeout(this.expirationClock);
+      }
+
+      // start the clock for when to destroy ourselves if we are not 0, infinitely
+      if (this.ttl > 0) {
+        this.expirationClock = setTimeout(this.onExpired.bind(this), this.ttl * 1000);
+      }
+
+      const fileReader: FileReader = new FileReader();
+
+      // when the file reader successfully loads array buffers, process them
+      fileReader.onload = async (event: Event) => {
+        // if image has been destroyed error out
         if (!this.image) {
-          reject(this);
+          onerror();
+          return;
         }
 
-        // store the blob's file size
-        this._initialFileSize = blobData.size;
+        const buffer: Uint8Array = new Uint8Array((event.target as any).result);
+        this._mimeType = NgxAdvancedImgBitmap.detectMimeType(buffer, blobData.type);
 
-        // if we have an expiration clock ticking, clear it
-        if (this.expirationClock) {
-          clearTimeout(this.expirationClock);
+        // convert heic to jpeg if needed
+        if (this._mimeType === 'image/heic') {
+          console.log("Converting HEIC to JPEG");
+          const imageData = await NgxAdvancedImgBitmap.decodeHeic(buffer);
+          
+          // preserve quality settings used in heic2any
+          this.src = await NgxAdvancedImgBitmap.imageDataToBlob(imageData, 'image/jpeg', .92) as Blob;
+          
+          this._mimeType = this.src.type;
         }
 
-        // start the clock for when to destroy ourselves if we are not 0, infinitely
-        if (this.ttl > 0) {
-          this.expirationClock = setTimeout(this.onExpired.bind(this), this.ttl * 1000);
-        }
+        // wait for image load
 
-        const fileReader: FileReader = new FileReader();
-
-        // when the file reader successfully loads array buffers, process them
-        fileReader.onload = async (event: Event) => {
-          // if image has been destroyed error out
+        // image load success handler
+        this.image.onload = async () => {
           if (!this.image) {
-            onerror();
+            // throw error if image has been destroyed
             return;
           }
 
-          const buffer: Uint8Array = new Uint8Array((event.target as any).result);
-          this._mimeType = NgxAdvancedImgBitmap.detectMimeType(buffer, blobData.type);
+          const domURL: any = URL || webkitURL || window.URL;
 
-          // convert heic to jpeg if needed
-          if (this._mimeType === 'image/heic') {
-            console.log("still heic")
-            const imageData = await NgxAdvancedImgBitmap.decodeHeic(buffer);
-            
-            // preserve quality settings used in heic2any
-            this.src = await NgxAdvancedImgBitmap.imageDataToBlob(imageData, 'image/jpeg', .92);
-            
-            this._mimeType = 'image/jpeg';
-          }
+          if (this.mimeType !== 'image/svg+xml' || !allowXMLLoading) {
+            // if our browser doesn't support the URL implementation, fail the load
+            if (!domURL || !(domURL).createObjectURL) {
+              onerror();
 
-          // wait for image load
-
-          // image load success handler
-          this.image.onload = async () => {
-            console.log('image loaded');
-            if (!this.image) {
-              // throw error if image has been destroyed
               return;
             }
 
-            const domURL: any = URL || webkitURL || window.URL;
+            // create a canvas to paint to
+            let canvas: HTMLCanvasElement | null = document.createElement('canvas');
 
-            if (this.mimeType !== 'image/svg+xml' || !allowXMLLoading) {
-              // if our browser doesn't support the URL implementation, fail the load
-              if (!domURL || !(domURL).createObjectURL) {
-                onerror();
+            // configure the dimensions of the canvas
+            canvas.width = this.image.width;
+            canvas.height = this.image.height;
 
-                return;
+            // acquire the rendering context
+            const ctx: CanvasRenderingContext2D | null = canvas?.getContext('2d', { desynchronized: false, willReadFrequently: true });
+
+            // if the context cannot be acquired, we should quit the operation
+            if (!ctx) {
+              onerror();
+
+              return;
+            }
+
+            // Enable image smoothing
+            ctx.imageSmoothingEnabled = true;
+            ctx.imageSmoothingQuality = 'high';
+
+            ctx.drawImage(this.image, 0, 0);
+
+            // if we haven't loaded anonymously, we'll taint the canvas and crash the application
+            let dataUri: string = (anonymous) ? canvas.toDataURL(this._mimeType, fullQualityLoad ? 1 : undefined) : '';
+
+            if (typeof this.src === 'string') {
+              // store the exif data
+              exif.parse(blobData, true).then((exifData: any) => {
+                this._exifData = exifData || {};
+              });
+            }
+
+            // if we got the bitmap data, create the link to download and invoke it
+            if (dataUri) {
+              // clear any existing object urls as necessary
+              if (this._objectURL) {
+                try {
+                  domURL.revokeObjectURL(this._objectURL);
+                } catch (error) {
+                }
               }
 
-              // create a canvas to paint to
-              let canvas: HTMLCanvasElement | null = document.createElement('canvas');
+              // get the bitmap data in blob format
+              this._objectURL = domURL.createObjectURL(NgxAdvancedImgBitmap.dataURItoBlob(dataUri));
+            }
 
-              // configure the dimensions of the canvas
-              canvas.width = this.image.width;
-              canvas.height = this.image.height;
+            // clean up the canvas
+            if (canvas) {
+              ctx?.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+              canvas.width = canvas.height = 0;
+              canvas = null;
+            }
 
-              // acquire the rendering context
-              const ctx: CanvasRenderingContext2D | null = canvas?.getContext('2d', { desynchronized: false, willReadFrequently: true });
+            this.loaded = true;
+            this.size = this.image.naturalWidth * this.image.naturalHeight;
 
-              // if the context cannot be acquired, we should quit the operation
-              if (!ctx) {
-                onerror();
+            const head: string = `data:${this._mimeType};base64,`;
+            this._fileSize = Math.round(atob(dataUri.substring(head.length)).length);
 
-                return;
-              }
+            // track the time at which this asset was first asked to load
+            this.loadedAt = new Date();
 
-              // Enable image smoothing
-              ctx.imageSmoothingEnabled = true;
-              ctx.imageSmoothingQuality = 'high';
+            // if we have an expiration clock ticking, clear it
+            if (this.expirationClock) {
+              clearTimeout(this.expirationClock);
+            }
 
-              ctx.drawImage(this.image, 0, 0);
+            await this.adjustForExifOrientation();
 
-              // if we haven't loaded anonymously, we'll taint the canvas and crash the application
-              let dataUri: string = (anonymous) ? canvas.toDataURL(this._mimeType, fullQualityLoad ? 1 : undefined) : '';
+            // if we loaded a non-svg, then we are done loading
+            resolve(this);
+          } else {
+            const client: XMLHttpRequest = new XMLHttpRequest();
+            client.open('GET', this.image.src);
+            client.onreadystatechange = () => {
+              // if the document ready state is finished and ready
+              if (client.readyState === 4) {
+                let svg: any = (new NgxAdvancedImgJxon()).stringToXml(client.responseText).getElementsByTagName('svg')[0];
 
-              if (typeof this.src === 'string') {
-                // store the exif data
-                exif.parse(blobData, true).then((exifData: any) => {
-                  this._exifData = exifData || {};
-                });
-              }
+                // 'viewBox' is now a string, parse the string for the viewBox values - can be separated by whitespace and/or a comma
+                const viewBox: string[] = svg.getAttribute('viewBox').split(/[ ,]/);
 
-              // if we got the bitmap data, create the link to download and invoke it
-              if (dataUri) {
+                // make sure the viewBox is set
+                if (viewBox.length !== 4) {
+                  onerror();
+
+                  return;
+                }
+
+                // get the width and height from the viewBox
+                const svgWidth: number = +viewBox[2];
+                const svgHeight: number = +viewBox[3];
+
+                // viewBox width and height is considered to be a required attribute, so check its existence and validity
+                if (
+                  !svgWidth ||
+                  !svgHeight ||
+                  isNaN(svgWidth) ||
+                  isNaN(svgHeight) ||
+                  !isFinite(svgWidth) ||
+                  !isFinite(svgHeight)
+                ) {
+                  onerror();
+
+                  return;
+                }
+
+                // set the width and height from the view box definition
+                svg.setAttribute('width', svgWidth);
+                svg.setAttribute('height', svgHeight);
+
+                // never preserve aspect ratio so the entire image fills the element boundaries
+                svg.setAttribute('preserveAspectRatio', 'none');
+
+                const svgXML: string = (new NgxAdvancedImgJxon()).xmlToString(svg);
+                svg = new Blob([svgXML], { type: this.mimeType + ';charset=utf-8' });
+
+                // if our browser doesn't support the URL implementation, fail the load
+                if (!this.image || !domURL || !(domURL).createObjectURL) {
+                  onerror();
+
+                  return;
+                }
+
+                this.image.onload = async () => {
+                  this.loaded = true;
+                  this.size = svgWidth * svgHeight;
+
+                  // track the time at which this asset was first asked to load
+                  this.loadedAt = new Date();
+
+                  // if we have an expiration clock ticking, clear it
+                  if (this.expirationClock) {
+                    clearTimeout(this.expirationClock);
+                  }
+
+                  await this.adjustForExifOrientation();
+
+                  // the image has successfully loaded
+                  resolve(this);
+                };
+
                 // clear any existing object urls as necessary
                 if (this._objectURL) {
                   try {
                     domURL.revokeObjectURL(this._objectURL);
                   } catch (error) {
+                    console.error(error);
                   }
                 }
 
-                // get the bitmap data in blob format
-                this._objectURL = domURL.createObjectURL(NgxAdvancedImgBitmap.dataURItoBlob(dataUri));
+                this.image.loading = 'eager';
+                this.image.src = this._objectURL = domURL.createObjectURL(svg);
               }
+            };
 
-              // clean up the canvas
-              if (canvas) {
-                ctx?.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
-                canvas.width = canvas.height = 0;
-                canvas = null;
-              }
-
-              this.loaded = true;
-              this.size = this.image.naturalWidth * this.image.naturalHeight;
-
-              const head: string = `data:${this._mimeType};base64,`;
-              this._fileSize = Math.round(atob(dataUri.substring(head.length)).length);
-
-              // track the time at which this asset was first asked to load
-              this.loadedAt = new Date();
-
-              // if we have an expiration clock ticking, clear it
-              if (this.expirationClock) {
-                clearTimeout(this.expirationClock);
-              }
-
-              await this.adjustForExifOrientation();
-
-              // if we loaded a non-svg, then we are done loading
-              resolve(this);
-            } else {
-              const client: XMLHttpRequest = new XMLHttpRequest();
-              client.open('GET', this.image.src);
-              client.onreadystatechange = () => {
-                // if the document ready state is finished and ready
-                if (client.readyState === 4) {
-                  let svg: any = (new NgxAdvancedImgJxon()).stringToXml(client.responseText).getElementsByTagName('svg')[0];
-
-                  // 'viewBox' is now a string, parse the string for the viewBox values - can be separated by whitespace and/or a comma
-                  const viewBox: string[] = svg.getAttribute('viewBox').split(/[ ,]/);
-
-                  // make sure the viewBox is set
-                  if (viewBox.length !== 4) {
-                    onerror();
-
-                    return;
-                  }
-
-                  // get the width and height from the viewBox
-                  const svgWidth: number = +viewBox[2];
-                  const svgHeight: number = +viewBox[3];
-
-                  // viewBox width and height is considered to be a required attribute, so check its existence and validity
-                  if (
-                    !svgWidth ||
-                    !svgHeight ||
-                    isNaN(svgWidth) ||
-                    isNaN(svgHeight) ||
-                    !isFinite(svgWidth) ||
-                    !isFinite(svgHeight)
-                  ) {
-                    onerror();
-
-                    return;
-                  }
-
-                  // set the width and height from the view box definition
-                  svg.setAttribute('width', svgWidth);
-                  svg.setAttribute('height', svgHeight);
-
-                  // never preserve aspect ratio so the entire image fills the element boundaries
-                  svg.setAttribute('preserveAspectRatio', 'none');
-
-                  const svgXML: string = (new NgxAdvancedImgJxon()).xmlToString(svg);
-                  svg = new Blob([svgXML], { type: this.mimeType + ';charset=utf-8' });
-
-                  // if our browser doesn't support the URL implementation, fail the load
-                  if (!this.image || !domURL || !(domURL).createObjectURL) {
-                    onerror();
-
-                    return;
-                  }
-
-                  this.image.onload = async () => {
-                    this.loaded = true;
-                    this.size = svgWidth * svgHeight;
-
-                    // track the time at which this asset was first asked to load
-                    this.loadedAt = new Date();
-
-                    // if we have an expiration clock ticking, clear it
-                    if (this.expirationClock) {
-                      clearTimeout(this.expirationClock);
-                    }
-
-                    await this.adjustForExifOrientation();
-
-                    // the image has successfully loaded
-                    resolve(this);
-                  };
-
-                  // clear any existing object urls as necessary
-                  if (this._objectURL) {
-                    try {
-                      domURL.revokeObjectURL(this._objectURL);
-                    } catch (error) {
-                    }
-                  }
-
-                  this.image.loading = 'eager';
-                  this.image.src = this._objectURL = domURL.createObjectURL(svg);
-                }
-              };
-
-              // issue the file load
-              client.send();
-            }
-          };
-
-          // image load failure handler
-          this.image.onerror = onerror;
-
-          // calculate a unique revision signature to ensure we pull the image with the correct CORS headers
-          let rev = '';
-          if (this.revision >= 0 && (typeof this.src === 'string' && this.src.indexOf('base64') === -1)) {
-            if (this.src.indexOf('?') >= 0) {
-              rev = '&rev=' + this.revision;
-            } else {
-              rev = '?rev=' + this.revision;
-            }
+            // issue the file load
+            client.send();
           }
+        };
 
-          // create a properly configured url despite protocol - make sure any resolution data is cleared
-          if (typeof this.src === 'string') {
-            if (this.resolution === '') {
-              // distinct loads should take the direct source url
-              url = this.src;
-            } else {
-              // clear resolution information if provided for situations where we intend to use some resolution
-              url = this.src.replace(/_(.*)/g, '');
-            }
+        // image load failure handler
+        this.image.onerror = onerror;
 
-            // append resolution and revision information for all scenarios if provided
-            url += this.resolution + rev;
-
-            // load the image
-            this.image.src = url
+        // calculate a unique revision signature to ensure we pull the image with the correct CORS headers
+        let rev = '';
+        if (this.revision >= 0 && (typeof this.src === 'string' && this.src.indexOf('base64') === -1)) {
+          if (this.src.indexOf('?') >= 0) {
+            rev = '&rev=' + this.revision;
           } else {
-            this.image.src = URL.createObjectURL(this.src);
-
-            // store the original blob file size
-            this._initialFileSize = this.src.size;
-
-            // parse the exif data direction while the image content loads
-            exif.parse(this.src, true).then((exifData: any) => {
-              this._exifData = exifData || {};
-            });
+            rev = '?rev=' + this.revision;
           }
-        };
+        }
 
-        // if we fail to load the file header data, throw an error to be captured by the promise catch
-        fileReader.onerror = () => {
-          throw new Error('Couldn\'t read file header for download');
-        };
+        // create a properly configured url despite protocol - make sure any resolution data is cleared
+        if (typeof this.src === 'string') {
+          if (this.resolution === '') {
+            // distinct loads should take the direct source url
+            url = this.src;
+          } else {
+            // clear resolution information if provided for situations where we intend to use some resolution
+            url = this.src.replace(/_(.*)/g, '');
+          }
 
-        // load the file data array buffer once we have the blob
-        fileReader.readAsArrayBuffer(blobData);
+          // append resolution and revision information for all scenarios if provided
+          url += this.resolution + rev;
 
+          // load the image
+          this.image.src = url
+        } else {
+          this.image.src = URL.createObjectURL(this.src);
+
+          // store the original blob file size
+          this._initialFileSize = this.src.size;
+
+          // parse the exif data direction while the image content loads
+          exif.parse(this.src, true).then((exifData: any) => {
+            this._exifData = exifData || {};
+          });
+        }
+      };
+
+      // if we fail to load the file header data, throw an error to be captured by the promise catch
+      fileReader.onerror = () => {
+        throw new Error('Couldn\'t read file header for download');
+      };
+
+      // load the file data array buffer once we have the blob
+      fileReader.readAsArrayBuffer(blobData);
 
       // image loading error handler
       const onerror: () => Promise<void> = async () => {
@@ -876,7 +866,9 @@ export class NgxAdvancedImgBitmap {
       maxDimension,
       options,
       undefined,
-    );
+    ).catch((error: any) => {
+      return Promise.reject(error);
+    });
   }
 
   /**
@@ -903,320 +895,321 @@ export class NgxAdvancedImgBitmap {
     lastOp?: 'quality' | 'scale' | undefined,
     lastSize?: number,
   ): Promise<INgxAdvancedImgBitmapOptimization> {
-    return new Promise(async (resolve: (value: INgxAdvancedImgBitmapOptimization) => void) => {
-      if (
-        !this.image ||
-        !this.loaded
-      ) {
-        throw new Error('Image not loaded');
-      }
-
-      if (quality < 0 || quality > 1) {
-        throw new Error('The requested image optimization cannot be achieved');
-      }
-
-      // draw the image to the canvas
-      let canvas: HTMLCanvasElement | null = document.createElement('canvas');
-      let width: number = canvas.width = this.image.width * resizeFactor;
-      let height: number = canvas.height = this.image.height * resizeFactor;
-      let minThresholdReached = false;
-
-      // cap the size of the canvas in accordance with te minDimension constraints for optimization
-      if (
-        resizeFactor < 1 &&
-        typeof options?.minDimension === 'number' &&
-        !isNaN(options?.minDimension) &&
-        isFinite(options?.minDimension) &&
-        options?.minDimension > 0 &&
-        (canvas.width < options?.minDimension || canvas.height < options?.minDimension)
-      ) {
-        let minDimensionAspectRatio = canvas.width / canvas.height;
-
-        if (canvas.width > canvas.height) {
-          height = canvas.height = options?.minDimension;
-          width = canvas.width = options?.minDimension * minDimensionAspectRatio;
-        } else {
-          minDimensionAspectRatio = canvas.height / canvas.width;
-          width = canvas.width = options?.minDimension;
-          height = canvas.height = options?.minDimension * minDimensionAspectRatio;
-        }
-
-        minThresholdReached = true;
-      }
-
-      if (
-        typeof options?.minQuality === 'number' &&
-        !isNaN(options?.minQuality) &&
-        isFinite(options?.minQuality) &&
-        options?.minQuality >= 0 &&
-        quality < options?.minQuality
-      ) {
-        minThresholdReached = true;
-      }
-
-      if (
-        typeof options?.minScale === 'number' &&
-        !isNaN(options?.minScale) &&
-        isFinite(options?.minScale) &&
-        options?.minScale >= 0 &&
-        resizeFactor < options?.minScale
-      ) {
-        minThresholdReached = true;
-      }
-
-      // scale the image down based on the max allowed pixel dimension
-      if (
-        typeof maxDimension === 'number' &&
-        !isNaN(maxDimension) &&
-        isFinite(maxDimension) &&
-        maxDimension > 0
-      ) {
-        if (canvas.width > maxDimension) {
-          height = canvas.height = canvas.height * (maxDimension / canvas.width);
-          width = canvas.width = maxDimension;
-          resizeFactor = maxDimension / this.image.width;
-        }
-
-        if (canvas.height > maxDimension) {
-          width = canvas.width = canvas.width * (maxDimension / canvas.height);
-          height = canvas.height = maxDimension;
-          resizeFactor = maxDimension / this.image.height;
-        }
-      }
-
-      const ctx: CanvasRenderingContext2D | null = canvas?.getContext('2d', { desynchronized: false, willReadFrequently: true });
-
-      ctx?.drawImage(
-        this.image,
-        0,
-        0,
-        canvas.width,
-        canvas.height,
-      );
-
-      // if we haven't loaded anonymously, we'll taint the canvas and crash the application
-      //let dataUri: string = canvas.toDataURL(type, quality);
-      let blob = await NgxAdvancedImgBitmap.canvasToBlobPromise(canvas, type, quality);
-
-      // clean up the canvas
-      if (canvas) {
-        ctx?.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
-        canvas.width = canvas.height = 0;
-        canvas = null;
-      }
-
-      const domURL: any = URL || webkitURL || window.URL;
-
-
-      if (!blob) {
-        throw new Error('An error occurred while drawing to the canvas');
-      }
-
-      if (typeof options?.sizeLimit === 'number' && !isNaN(options?.sizeLimit) && isFinite(options?.sizeLimit) && options?.sizeLimit > 0) {
-        const fileSize: number = Math.round(blob.size);
-
-        // if (this.debug) {
-        //   console.warn('Image Optimization Factors:', options?.mode, quality, resizeFactor, `${fileSize} B`);
-        // }
-
+    return new Promise(async (resolve: (value: INgxAdvancedImgBitmapOptimization) => void, reject) => {
+      try {
         if (
-          fileSize > options?.sizeLimit &&
-          (!lastSize || (lastSize && Math.ceil(fileSize) <= Math.ceil(lastSize))) // consider rounding errors
+          !this.image ||
+          !this.loaded
         ) {
-          if (resizeFactor === undefined) {
-            // if the resize factor wasn't supplied set to 1
-            resizeFactor = 1;
+          throw new Error('Image not loaded');
+        }
+  
+        if (quality < 0 || quality > 1) {
+          throw new Error('The requested image optimization cannot be achieved');
+        }
+  
+        // draw the image to the canvas
+        let canvas: HTMLCanvasElement | null = document.createElement('canvas');
+        let width: number = canvas.width = this.image.width * resizeFactor;
+        let height: number = canvas.height = this.image.height * resizeFactor;
+        let minThresholdReached = false;
+  
+        // cap the size of the canvas in accordance with te minDimension constraints for optimization
+        if (
+          resizeFactor < 1 &&
+          typeof options?.minDimension === 'number' &&
+          !isNaN(options?.minDimension) &&
+          isFinite(options?.minDimension) &&
+          options?.minDimension > 0 &&
+          (canvas.width < options?.minDimension || canvas.height < options?.minDimension)
+        ) {
+          let minDimensionAspectRatio = canvas.width / canvas.height;
+  
+          if (canvas.width > canvas.height) {
+            height = canvas.height = options?.minDimension;
+            width = canvas.width = options?.minDimension * minDimensionAspectRatio;
+          } else {
+            minDimensionAspectRatio = canvas.height / canvas.width;
+            width = canvas.width = options?.minDimension;
+            height = canvas.height = options?.minDimension * minDimensionAspectRatio;
           }
-
-          if (resizeFactor <= 0) {
-            throw new Error('Invalid resize factor reached (<= 0)');
+  
+          minThresholdReached = true;
+        }
+  
+        if (
+          typeof options?.minQuality === 'number' &&
+          !isNaN(options?.minQuality) &&
+          isFinite(options?.minQuality) &&
+          options?.minQuality >= 0 &&
+          quality < options?.minQuality
+        ) {
+          minThresholdReached = true;
+        }
+  
+        if (
+          typeof options?.minScale === 'number' &&
+          !isNaN(options?.minScale) &&
+          isFinite(options?.minScale) &&
+          options?.minScale >= 0 &&
+          resizeFactor < options?.minScale
+        ) {
+          minThresholdReached = true;
+        }
+  
+        // scale the image down based on the max allowed pixel dimension
+        if (
+          typeof maxDimension === 'number' &&
+          !isNaN(maxDimension) &&
+          isFinite(maxDimension) &&
+          maxDimension > 0
+        ) {
+          if (canvas.width > maxDimension) {
+            height = canvas.height = canvas.height * (maxDimension / canvas.width);
+            width = canvas.width = maxDimension;
+            resizeFactor = maxDimension / this.image.width;
           }
-
-          let qualityFloor = 0.025;
-          let scaleFloor = 0.025;
-          let preferredOp: 'prefer-size' | 'prefer-quality';
-
-          // Ensure that minQuality is adhered
-          if (options?.minQuality) {
-            qualityFloor = options?.minQuality;
-            qualityFloor = (qualityFloor < 0) ? 0 : (qualityFloor > 1) ? 1 : qualityFloor;
+  
+          if (canvas.height > maxDimension) {
+            width = canvas.width = canvas.width * (maxDimension / canvas.height);
+            height = canvas.height = maxDimension;
+            resizeFactor = maxDimension / this.image.height;
           }
-
-          // Ensure that minScale is adhered
-          if (options?.minScale) {
-            scaleFloor = options?.minScale;
-            scaleFloor = (scaleFloor < 0) ? 0 : (scaleFloor > 1) ? 1 : scaleFloor;
-          }
-
-          switch (options?.mode) {
-            case 'alternating-preference':
-              if (lastOp === 'quality') {
+        }
+  
+        const ctx: CanvasRenderingContext2D | null = canvas?.getContext('2d', { desynchronized: false, willReadFrequently: true });
+  
+        ctx?.drawImage(
+          this.image,
+          0,
+          0,
+          canvas.width,
+          canvas.height,
+        );
+  
+        // if we haven't loaded anonymously, we'll taint the canvas and crash the application
+        let blob = await NgxAdvancedImgBitmap.canvasToBlobPromise(canvas, type, quality);
+  
+        // clean up the canvas
+        if (canvas) {
+          ctx?.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+          canvas.width = canvas.height = 0;
+          canvas = null;
+        }
+  
+        if (!blob) {
+          throw new Error('An error occurred while drawing to the canvas');
+        }
+  
+        if (typeof options?.sizeLimit === 'number' && !isNaN(options?.sizeLimit) && isFinite(options?.sizeLimit) && options?.sizeLimit > 0) {
+          const fileSize: number = Math.round(blob.size);
+  
+          // if (this.debug) {
+          //   console.warn('Image Optimization Factors:', options?.mode, quality, resizeFactor, `${fileSize} B`);
+          // }
+  
+          if (
+            fileSize > options?.sizeLimit &&
+            (!lastSize || (lastSize && Math.ceil(fileSize) <= Math.ceil(lastSize))) // consider rounding errors
+          ) {
+            if (resizeFactor === undefined) {
+              // if the resize factor wasn't supplied set to 1
+              resizeFactor = 1;
+            }
+  
+            if (resizeFactor <= 0) {
+              throw new Error('Invalid resize factor reached (<= 0)');
+            }
+  
+            let qualityFloor = 0.025;
+            let scaleFloor = 0.025;
+            let preferredOp: 'prefer-size' | 'prefer-quality';
+  
+            // Ensure that minQuality is adhered
+            if (options?.minQuality) {
+              qualityFloor = options?.minQuality;
+              qualityFloor = (qualityFloor < 0) ? 0 : (qualityFloor > 1) ? 1 : qualityFloor;
+            }
+  
+            // Ensure that minScale is adhered
+            if (options?.minScale) {
+              scaleFloor = options?.minScale;
+              scaleFloor = (scaleFloor < 0) ? 0 : (scaleFloor > 1) ? 1 : scaleFloor;
+            }
+  
+            switch (options?.mode) {
+              case 'alternating-preference':
+                if (lastOp === 'quality') {
+                  preferredOp = 'prefer-size';
+                  lastOp = 'scale';
+                } else {
+                  preferredOp = 'prefer-quality'
+                  lastOp = 'quality';
+                }
+                break;
+  
+              case 'retain-size':
+                scaleFloor = 1;
+  
+                preferredOp = 'prefer-quality';
+                lastOp = 'quality';
+  
+                break;
+  
+              case 'retain-quality':
+                qualityFloor = 1;
+  
                 preferredOp = 'prefer-size';
                 lastOp = 'scale';
-              } else {
-                preferredOp = 'prefer-quality'
+                break;
+  
+              case 'prefer-quality':
+                preferredOp = 'prefer-quality';
+                lastOp = 'scale';
+  
+                break;
+  
+              case 'prefer-size':
+              default:
+                preferredOp = 'prefer-size';
                 lastOp = 'quality';
-              }
-              break;
-
-            case 'retain-size':
-              scaleFloor = 1;
-
-              preferredOp = 'prefer-quality';
-              lastOp = 'quality';
-
-              break;
-
-            case 'retain-quality':
-              qualityFloor = 1;
-
-              preferredOp = 'prefer-size';
-              lastOp = 'scale';
-              break;
-
-            case 'prefer-quality':
-              preferredOp = 'prefer-quality';
-              lastOp = 'scale';
-
-              break;
-
-            case 'prefer-size':
-            default:
-              preferredOp = 'prefer-size';
-              lastOp = 'quality';
-              break;
-          }
-
-          /**
-           * perform the optimization based on the preferred operation
-           */
-
-          switch (preferredOp) {
-            case 'prefer-quality':
-              // base case if we are at our bottom quality and resize factor, resolve
-              if (!options?.strict && (quality <= qualityFloor && resizeFactor <= scaleFloor) || minThresholdReached) {
-                const exifData: any = JSON.parse(JSON.stringify(this.exifData));
-
-                exifData['ExifImageWidth'] = width;
-                exifData['ExifImageHeight'] = height;
-
-                resolve({
-                  blob,
-                  exifData,
-                } as INgxAdvancedImgBitmapOptimization);
-
+                break;
+            }
+  
+            /**
+             * perform the optimization based on the preferred operation
+             */
+  
+            switch (preferredOp) {
+              case 'prefer-quality':
+                // base case if we are at our bottom quality and resize factor, resolve
+                if (!options?.strict && (quality <= qualityFloor && resizeFactor <= scaleFloor) || minThresholdReached) {
+                  const exifData: any = JSON.parse(JSON.stringify(this.exifData));
+  
+                  exifData['ExifImageWidth'] = width;
+                  exifData['ExifImageHeight'] = height;
+  
+                  resolve({
+                    blob,
+                    exifData,
+                  } as INgxAdvancedImgBitmapOptimization);
+  
+                  return;
+                }
+  
+                if (resizeFactor > scaleFloor) {
+                  if (options?.sizeLimit) {
+                    const oldResizeFactor: number = resizeFactor;
+                    const newDims: { width: number, height: number } = this.estimateNewDimensions(fileSize, options?.sizeLimit, width, height);
+  
+                    if (width > height) {
+                      resizeFactor = resizeFactor - (1 - (newDims.width / width));
+                    } else {
+                      resizeFactor = resizeFactor - (1 - (newDims.height / height));
+                    }
+  
+                    if (resizeFactor > oldResizeFactor) {
+                      resizeFactor = resizeFactor - NgxAdvancedImgBitmap.ITERATION_FACTOR;
+                    }
+                  }
+  
+                  if (resizeFactor < scaleFloor) {
+                    // keep it within a given scaling factor
+                    resizeFactor = scaleFloor;
+                  }
+  
+                  // if the quality is too high, reduce it and try again
+                  this._optimize(type, quality, resizeFactor, maxDimension, options, lastOp, fileSize).then((optimization: INgxAdvancedImgBitmapOptimization) => resolve(optimization));
+  
+                  return;
+                }
+  
+                // we've reduced scale, let's reduce image size
+                if (quality < qualityFloor) {
+                  if (options?.strict) {
+                    throw new Error('The requested image optimization cannot be achieved');
+                  }
+  
+                  // keep it within a given quality floor
+                  quality = qualityFloor;
+                }
+  
+                quality = quality - (((options?.sizeLimit ? (fileSize / options?.sizeLimit) * NgxAdvancedImgBitmap.PREDICTION_FACTOR : NgxAdvancedImgBitmap.QUALITY_FACTOR) / (options?.sizeLimit / fileSize) * NgxAdvancedImgBitmap.ITERATION_FACTOR));
+  
+                this._optimize(type, quality, resizeFactor, maxDimension, options, lastOp, fileSize).then((optimization: INgxAdvancedImgBitmapOptimization) => resolve(optimization));
+  
                 return;
-              }
-
-              if (resizeFactor > scaleFloor) {
+  
+              case 'prefer-size':
+                // base case if we are at our bottom quality and resize factor, resolve
+                if (!options?.strict && (quality <= qualityFloor && resizeFactor <= scaleFloor) || minThresholdReached) {
+                  const exifData: any = JSON.parse(JSON.stringify(this.exifData));
+  
+                  exifData['ExifImageWidth'] = width;
+                  exifData['ExifImageHeight'] = height;
+  
+                  return;
+                }
+  
+                if (quality > qualityFloor) {
+                  quality = quality - (((options?.sizeLimit ? (fileSize / options?.sizeLimit) * NgxAdvancedImgBitmap.PREDICTION_FACTOR : NgxAdvancedImgBitmap.QUALITY_FACTOR) / (options?.sizeLimit / fileSize) * NgxAdvancedImgBitmap.ITERATION_FACTOR));
+  
+                  if (quality < qualityFloor) {
+                    // keep it within a given quality floor
+                    quality = qualityFloor;
+                  }
+  
+                  // if the quality is too high, reduce it and try again
+                  this._optimize(type, quality, resizeFactor, maxDimension, options, lastOp, fileSize).then((optimization: INgxAdvancedImgBitmapOptimization) => resolve(optimization));
+  
+                  return;
+                }
+  
+                // we've reduced quality, let's reduce image size
                 if (options?.sizeLimit) {
                   const oldResizeFactor: number = resizeFactor;
                   const newDims: { width: number, height: number } = this.estimateNewDimensions(fileSize, options?.sizeLimit, width, height);
-
+  
                   if (width > height) {
                     resizeFactor = resizeFactor - (1 - (newDims.width / width));
                   } else {
                     resizeFactor = resizeFactor - (1 - (newDims.height / height));
                   }
-
+  
                   if (resizeFactor > oldResizeFactor) {
                     resizeFactor = resizeFactor - NgxAdvancedImgBitmap.ITERATION_FACTOR;
                   }
                 }
-
+  
                 if (resizeFactor < scaleFloor) {
+                  if (options?.strict) {
+                    throw new Error('The requested image optimization cannot be achieved');
+                  }
+  
                   // keep it within a given scaling factor
                   resizeFactor = scaleFloor;
                 }
-
-                // if the quality is too high, reduce it and try again
-                this._optimize(type, quality, resizeFactor, maxDimension, options, lastOp, fileSize).then((optimization: INgxAdvancedImgBitmapOptimization) => resolve(optimization));
-
+  
+                this._optimize(type, quality, resizeFactor, maxDimension, options, lastOp).then((optimization: INgxAdvancedImgBitmapOptimization) => resolve(optimization));
+  
                 return;
-              }
-
-              // we've reduced scale, let's reduce image size
-              if (quality < qualityFloor) {
-                if (options?.strict) {
-                  throw new Error('The requested image optimization cannot be achieved');
-                }
-
-                // keep it within a given quality floor
-                quality = qualityFloor;
-              }
-
-              quality = quality - (((options?.sizeLimit ? (fileSize / options?.sizeLimit) * NgxAdvancedImgBitmap.PREDICTION_FACTOR : NgxAdvancedImgBitmap.QUALITY_FACTOR) / (options?.sizeLimit / fileSize) * NgxAdvancedImgBitmap.ITERATION_FACTOR));
-
-              this._optimize(type, quality, resizeFactor, maxDimension, options, lastOp, fileSize).then((optimization: INgxAdvancedImgBitmapOptimization) => resolve(optimization));
-
-              return;
-
-            case 'prefer-size':
-              // base case if we are at our bottom quality and resize factor, resolve
-              if (!options?.strict && (quality <= qualityFloor && resizeFactor <= scaleFloor) || minThresholdReached) {
-                const exifData: any = JSON.parse(JSON.stringify(this.exifData));
-
-                exifData['ExifImageWidth'] = width;
-                exifData['ExifImageHeight'] = height;
-
-                return;
-              }
-
-              if (quality > qualityFloor) {
-                quality = quality - (((options?.sizeLimit ? (fileSize / options?.sizeLimit) * NgxAdvancedImgBitmap.PREDICTION_FACTOR : NgxAdvancedImgBitmap.QUALITY_FACTOR) / (options?.sizeLimit / fileSize) * NgxAdvancedImgBitmap.ITERATION_FACTOR));
-
-                if (quality < qualityFloor) {
-                  // keep it within a given quality floor
-                  quality = qualityFloor;
-                }
-
-                // if the quality is too high, reduce it and try again
-                this._optimize(type, quality, resizeFactor, maxDimension, options, lastOp, fileSize).then((optimization: INgxAdvancedImgBitmapOptimization) => resolve(optimization));
-
-                return;
-              }
-
-              // we've reduced quality, let's reduce image size
-              if (options?.sizeLimit) {
-                const oldResizeFactor: number = resizeFactor;
-                const newDims: { width: number, height: number } = this.estimateNewDimensions(fileSize, options?.sizeLimit, width, height);
-
-                if (width > height) {
-                  resizeFactor = resizeFactor - (1 - (newDims.width / width));
-                } else {
-                  resizeFactor = resizeFactor - (1 - (newDims.height / height));
-                }
-
-                if (resizeFactor > oldResizeFactor) {
-                  resizeFactor = resizeFactor - NgxAdvancedImgBitmap.ITERATION_FACTOR;
-                }
-              }
-
-              if (resizeFactor < scaleFloor) {
-                if (options?.strict) {
-                  throw new Error('The requested image optimization cannot be achieved');
-                }
-
-                // keep it within a given scaling factor
-                resizeFactor = scaleFloor;
-              }
-
-              this._optimize(type, quality, resizeFactor, maxDimension, options, lastOp).then((optimization: INgxAdvancedImgBitmapOptimization) => resolve(optimization));
-
-              return;
+            }
           }
         }
+  
+        const exifData: any = JSON.parse(JSON.stringify(this.exifData));
+  
+        exifData['ExifImageWidth'] = width;
+        exifData['ExifImageHeight'] = height;
+  
+        resolve({
+          blob,
+          exifData,
+        } as INgxAdvancedImgBitmapOptimization);
+      } catch (error) {
+        reject(error);
       }
-
-      const exifData: any = JSON.parse(JSON.stringify(this.exifData));
-
-      exifData['ExifImageWidth'] = width;
-      exifData['ExifImageHeight'] = height;
-
-      resolve({
-        blob,
-        exifData,
-      } as INgxAdvancedImgBitmapOptimization);
+      
     });
   }
 

--- a/projects/ngx-advanced-img/src/lib/classes/bitmap.ts
+++ b/projects/ngx-advanced-img/src/lib/classes/bitmap.ts
@@ -223,7 +223,7 @@ export class NgxAdvancedImgBitmap {
     this._mimeType = 'unknown';
     this._objectURL = '';
     this._fileSize = this._initialFileSize = 0;
-    this._exifData = null; // prevent failure when using JSON.parse on undefined
+    this._exifData = {}; // prevent failure when using JSON.parse on undefined
     this.debug = false;
   }
 
@@ -603,7 +603,7 @@ export class NgxAdvancedImgBitmap {
               if (typeof this.src === 'string') {
                 // store the exif data
                 exif.parse(blobData, true).then((exifData: any) => {
-                  this._exifData = exifData;
+                  this._exifData = exifData || {};
                 });
               }
 
@@ -771,7 +771,7 @@ export class NgxAdvancedImgBitmap {
 
             // parse the exif data direction while the image content loads
             exif.parse(this.src, true).then((exifData: any) => {
-              this._exifData = exifData;
+              this._exifData = exifData || {};
             });
           }
         };

--- a/projects/ngx-advanced-img/src/lib/classes/bitmap.ts
+++ b/projects/ngx-advanced-img/src/lib/classes/bitmap.ts
@@ -55,16 +55,16 @@ export class NgxAdvancedImgBitmap {
   public image: HTMLImageElement | undefined;
   public size: number;
   public debug: boolean; // set to true for console logging
-  private _ttl: number;	// time to live in seconds after it has been loaded
-  private loadedAt: Date | null;
-  private expirationClock: Timeout | null;
-  private _destroyed: Subject<INgxAdvancedImgBitmapDataSignature> | undefined;
-  private _objectURL: string;
-  private _exifData: any;
-  private _mimeType: string;
-  private _orientation: number;
-  private _fileSize: number;
-  private _initialFileSize: number;
+  protected _ttl: number;	// time to live in seconds after it has been loaded
+  protected loadedAt: Date | null;
+  protected expirationClock: Timeout | null;
+  protected _destroyed: Subject<INgxAdvancedImgBitmapDataSignature> | undefined;
+  protected _objectURL: string;
+  protected _exifData: any;
+  protected _mimeType: string;
+  protected _orientation: number;
+  protected _fileSize: number;
+  protected _initialFileSize: number;
 
   /**
    * The object URL format of the image that can be used for direct downloading to an end-user's machine.
@@ -362,7 +362,7 @@ export class NgxAdvancedImgBitmap {
     });
   }
 
-  private static imageDataToBlob(imageData: ImageData, mimeType: string, quality: number): Promise<Blob> {
+  protected static imageDataToBlob(imageData: ImageData, mimeType: string, quality: number): Promise<Blob> {
     return new Promise((resolve, reject) => {
       let canvas = document.createElement('canvas');
       canvas.width = imageData.width;
@@ -403,7 +403,7 @@ export class NgxAdvancedImgBitmap {
     });
   }
 
-  private static async decodeHeic(buffer: Uint8Array): Promise<ImageData> {
+  protected static async decodeHeic(buffer: Uint8Array): Promise<ImageData> {
       const decoder = new libheif.HeifDecoder();
       let imagesArr = decoder.decode(buffer);
       if (!imagesArr || !imagesArr.length) {
@@ -544,9 +544,10 @@ export class NgxAdvancedImgBitmap {
 
           // convert heic to jpeg if needed
           if (this._mimeType === 'image/heic') {
-            const imageData = await NgxAdvancedImgBitmap.decodeHeic(buffer);
-            this.src = await NgxAdvancedImgBitmap.imageDataToBlob(imageData, 'image/jpeg', .92);
-            this._mimeType = 'image/jpeg';
+            console.log("still heic")
+            // const imageData = await NgxAdvancedImgBitmap.decodeHeic(buffer);
+            // this.src = await NgxAdvancedImgBitmap.imageDataToBlob(imageData, 'image/jpeg', .92);
+            // this._mimeType = 'image/jpeg';
           }
 
           // wait for image load
@@ -1255,7 +1256,7 @@ export class NgxAdvancedImgBitmap {
    * Helper function that adjusts the image based on any exif data indicating
    * a different orientation be performed.
    */
-  private async adjustForExifOrientation(): Promise<void> {
+  protected async adjustForExifOrientation(): Promise<void> {
     if (!this.image) {
       return Promise.reject(new Error('Image not loaded'));
     }
@@ -1278,7 +1279,7 @@ export class NgxAdvancedImgBitmap {
   /**
    * Event handler for when expiration clocks are complete and we must dispose of ourselves.
    */
-  private onExpired(): void {
+  protected onExpired(): void {
     // only destroy if we had been loaded, otherwise let the loading pathways dispose of this bitmap
     if (this.loaded) {
       this.destroy();

--- a/projects/ngx-advanced-img/src/lib/classes/bitmap.ts
+++ b/projects/ngx-advanced-img/src/lib/classes/bitmap.ts
@@ -223,6 +223,7 @@ export class NgxAdvancedImgBitmap {
     this._mimeType = 'unknown';
     this._objectURL = '';
     this._fileSize = this._initialFileSize = 0;
+    this._exifData = null; // prevent failure when using JSON.parse on undefined
     this.debug = false;
   }
 

--- a/projects/ngx-advanced-img/src/lib/classes/bitmap.ts
+++ b/projects/ngx-advanced-img/src/lib/classes/bitmap.ts
@@ -1285,23 +1285,4 @@ export class NgxAdvancedImgBitmap {
     // the expiration clock is now complete
     this.expirationClock = null;
   }
-
-  /**
-   * Fetch the blob info for a given url.
-   *
-   * @param url The url to the image to load the blob data.
-   */
-  private async getImageBlob(url: string, anonymous: boolean): Promise<Blob> {
-    const headers: Headers = new Headers();
-    headers.set('Access-Control-Allow-Origin', '*');
-
-    const response: Response = await fetch(url, {
-      method: 'GET',
-      mode: !anonymous ? 'no-cors' : undefined,
-      headers,
-    });
-
-    return response.blob();
-  }
-
 }

--- a/projects/ngx-advanced-img/src/lib/classes/bitmap.ts
+++ b/projects/ngx-advanced-img/src/lib/classes/bitmap.ts
@@ -545,9 +545,12 @@ export class NgxAdvancedImgBitmap {
           // convert heic to jpeg if needed
           if (this._mimeType === 'image/heic') {
             console.log("still heic")
-            // const imageData = await NgxAdvancedImgBitmap.decodeHeic(buffer);
-            // this.src = await NgxAdvancedImgBitmap.imageDataToBlob(imageData, 'image/jpeg', .92);
-            // this._mimeType = 'image/jpeg';
+            const imageData = await NgxAdvancedImgBitmap.decodeHeic(buffer);
+            
+            // preserve quality settings used in heic2any
+            this.src = await NgxAdvancedImgBitmap.imageDataToBlob(imageData, 'image/jpeg', .92);
+            
+            this._mimeType = 'image/jpeg';
           }
 
           // wait for image load

--- a/projects/ngx-advanced-img/src/lib/classes/heic-converter.ts
+++ b/projects/ngx-advanced-img/src/lib/classes/heic-converter.ts
@@ -26,7 +26,7 @@ export class NgxAdvancedImgHeicConverter {
 					  "ERR_LIBHEIF Error while processing single image and generating image data, could not ensure image"
 				  );
 			  }
-        
+
 				resolve(imageData);
 			});
 		});
@@ -113,7 +113,7 @@ export class NgxAdvancedImgHeicConverter {
 
 			// if we fail to load the file header data, throw an error to be captured by the promise catch
 			fileReader.onerror = () => {
-				throw new Error('Couldn\'t read file header for download');
+        reject(new Error('Failed to load file header data'));
 			};
 	
 			// load the file data array buffer once we have the blob

--- a/projects/ngx-advanced-img/src/lib/classes/heic-converter.ts
+++ b/projects/ngx-advanced-img/src/lib/classes/heic-converter.ts
@@ -63,9 +63,9 @@ export class NgxAdvancedImgHeicConverter {
   }
 
   /**
-   * 
+   * Decodes a buffer containing HEIC data into an ImageData object using the libheif-js WebAssembly bundle.
    * @param buffer 
-   * @returns 
+   * @returns ImageData object containg raw pixel data
    */
 	protected static async decodeHeic(buffer: Uint8Array): Promise<ImageData> {
 		const decoder = new libheif.HeifDecoder();
@@ -75,7 +75,7 @@ export class NgxAdvancedImgHeicConverter {
 			throw "ERR_LIBHEIF format not supported";
 		}
 
-		imagesArr = imagesArr.filter((x: any) => {
+		imagesArr = imagesArr.filter((x: libheif.DecodeResult) => {
 			let valid = true;
 			try {
         /*

--- a/projects/ngx-advanced-img/src/lib/classes/heic-converter.ts
+++ b/projects/ngx-advanced-img/src/lib/classes/heic-converter.ts
@@ -1,0 +1,123 @@
+import * as exif from 'exifr';
+
+// @ts-ignore
+import libheif from 'libheif-js/wasm-bundle';
+
+export interface INgxAdvancedImgHeicConversion {
+	exifData: any;
+	blob: Blob;
+}
+
+export class NgxAdvancedImgHeicConverter {
+
+	private static processSingleImage(image: any): Promise<ImageData> {
+		return new Promise((resolve, reject) => {
+			const w = image.get_width();
+			const h = image.get_height();
+			const whiteImage = new ImageData(w, h);
+			
+      for (let i = 0; i < w * h; i++) {
+				whiteImage.data[i * 4 + 3] = 255;
+			}
+			
+      image.display(whiteImage, (imageData: ImageData | null) => {
+			  if (!imageData) {
+				  return reject(
+					  "ERR_LIBHEIF Error while processing single image and generating image data, could not ensure image"
+				  );
+			  }
+        
+				resolve(imageData);
+			});
+		});
+	}
+
+  protected static imageDataToBlobOffscreen(imageData: ImageData, mimeType: string, quality: number): Promise<Blob> {
+    return new Promise((resolve, reject) => {
+      // Create an offscreen canvas
+      let offscreenCanvas = new OffscreenCanvas(imageData.width, imageData.height);
+      let ctx = offscreenCanvas.getContext('2d');
+      if (!ctx) {
+        throw new Error('Could not get 2d context');
+      }
+  
+      ctx.putImageData(imageData, 0, 0);
+
+      offscreenCanvas.convertToBlob({ type: mimeType, quality: quality }).then(resolve).catch((error) => {
+        reject("ERR_CANVAS Error on converting imagedata to blob: " + error);
+      });
+    });
+  }
+
+	protected static async decodeHeic(buffer: Uint8Array): Promise<ImageData> {
+		const decoder = new libheif.HeifDecoder();
+		let imagesArr = decoder.decode(buffer);
+		
+    if (!imagesArr || !imagesArr.length) {
+			throw "ERR_LIBHEIF format not supported";
+		}
+
+		imagesArr = imagesArr.filter((x: any) => {
+			let valid = true;
+			try {
+        /*
+        sometimes the heic container is valid
+        yet the images themselves are corrupt
+        */
+        x.get_height();
+			} catch (e) {
+			  valid = false;
+			}
+			
+      return valid;
+		});
+
+		if (!imagesArr.length) {
+			throw "ERR_LIBHEIF Heic doesn't contain valid images";
+		}
+	
+		// use the first frame if heic contains multiple images
+		return NgxAdvancedImgHeicConverter.processSingleImage(imagesArr[0]);
+	}
+
+
+	public static async convert(src: Blob): Promise<INgxAdvancedImgHeicConversion> {
+		// if no valid source, then reject the load
+		if (!src) {
+			return Promise.reject(new Error('No valid source provided'));
+		}
+		
+		return new Promise((resolve, reject) => {
+      // begin parsing exif data
+      const exifPromise = exif.parse(src, true);
+
+			const fileReader: FileReader = new FileReader();
+
+			// when the file reader successfully loads array buffers, process them
+			fileReader.onload = async (event: Event) => {
+        const buffer: Uint8Array = new Uint8Array((event.target as any).result);
+
+        const imageData = await NgxAdvancedImgHeicConverter.decodeHeic(buffer);
+        
+        const blob = await NgxAdvancedImgHeicConverter.imageDataToBlobOffscreen(imageData, 'image/jpeg', .92);
+
+        const exifData = await exifPromise;
+
+        console.log(exifData);
+
+        resolve({
+          exifData,
+          blob: blob
+        });
+			};
+
+			// if we fail to load the file header data, throw an error to be captured by the promise catch
+			fileReader.onerror = () => {
+				throw new Error('Couldn\'t read file header for download');
+			};
+	
+			// load the file data array buffer once we have the blob
+			fileReader.readAsArrayBuffer(src);
+		});
+	}
+}

--- a/projects/ngx-advanced-img/src/lib/classes/heic-converter.ts
+++ b/projects/ngx-advanced-img/src/lib/classes/heic-converter.ts
@@ -105,7 +105,7 @@ export class NgxAdvancedImgHeicConverter {
    * @param src 
    * @returns 
    */
-	public static async convert(src: Blob): Promise<INgxAdvancedImgHeicConversion> {
+	public static async convert(src: Blob, mimeType: string = 'image/jpeg'): Promise<INgxAdvancedImgHeicConversion> {
 		// if no valid source, then reject the load
 		if (!src) {
 			return Promise.reject(new Error('No valid source provided'));
@@ -122,7 +122,7 @@ export class NgxAdvancedImgHeicConverter {
 
         const imageData = await NgxAdvancedImgHeicConverter.decodeHeic(buffer);
         
-        const blob = await NgxAdvancedImgHeicConverter.imageDataToBlobOffscreen(imageData, 'image/jpeg', .92);
+        const blob = await NgxAdvancedImgHeicConverter.imageDataToBlobOffscreen(imageData, mimeType, .92);
 
         const exifData = await exifPromise;
 

--- a/projects/ngx-advanced-img/src/lib/classes/heic-converter.ts
+++ b/projects/ngx-advanced-img/src/lib/classes/heic-converter.ts
@@ -15,7 +15,7 @@ export class NgxAdvancedImgHeicConverter {
    * @param image DecodeResult object from libheif-js
    * @returns Promise resolving to an ImageData object
    */
-	private static processSingleImage(image: libheif.DecodeResult): Promise<ImageData> {
+	public static processSingleImage(image: libheif.DecodeResult): Promise<ImageData> {
 		return new Promise((resolve, reject) => {
 			const w = image.get_width();
 			const h = image.get_height();
@@ -45,7 +45,7 @@ export class NgxAdvancedImgHeicConverter {
    * @param quality The quality of the resulting conversion
    * @returns 
    */
-  protected static imageDataToBlobOffscreen(imageData: ImageData, mimeType: string, quality: number): Promise<Blob> {
+  public static imageDataToBlobOffscreen(imageData: ImageData, mimeType: string, quality: number): Promise<Blob> {
     return new Promise((resolve, reject) => {
       // Create an offscreen canvas
       let offscreenCanvas = new OffscreenCanvas(imageData.width, imageData.height);
@@ -67,7 +67,7 @@ export class NgxAdvancedImgHeicConverter {
    * @param buffer 
    * @returns ImageData object containg raw pixel data
    */
-	protected static async decodeHeic(buffer: Uint8Array): Promise<ImageData> {
+	public static async decodeHeic(buffer: Uint8Array): Promise<ImageData> {
 		const decoder = new libheif.HeifDecoder();
 		let imagesArr = decoder.decode(buffer);
 		

--- a/projects/ngx-advanced-img/src/lib/classes/heic-converter.ts
+++ b/projects/ngx-advanced-img/src/lib/classes/heic-converter.ts
@@ -1,5 +1,4 @@
 import * as exif from 'exifr';
-
 // @ts-ignore
 import libheif from 'libheif-js/wasm-bundle';
 
@@ -16,7 +15,7 @@ export class NgxAdvancedImgHeicConverter {
    * @param image DecodeResult object from libheif-js
    * @returns Promise resolving to an ImageData object
    */
-	private static processSingleImage(image: any): Promise<ImageData> {
+	private static processSingleImage(image: libheif.DecodeResult): Promise<ImageData> {
 		return new Promise((resolve, reject) => {
 			const w = image.get_width();
 			const h = image.get_height();

--- a/projects/ngx-advanced-img/src/lib/types/libheif.d.ts
+++ b/projects/ngx-advanced-img/src/lib/types/libheif.d.ts
@@ -1,0 +1,22 @@
+declare module 'libheif-js/wasm-bundle' {
+	interface DecodeResult {
+		img: {
+			is_primary: boolean;
+			thumbnails: number;
+			width: number;
+			height: number;
+		} | null;
+		get_width: () => number;
+		get_height: () => number;
+		is_primary: () => boolean;
+		display: (
+			base: ImageData,
+			callback: (result: ImageData | null) => void
+		) => void;
+	}
+
+	type DecodeResultType = DecodeResult[];
+	class HeifDecoder {
+		decode(buffer: ArrayBuffer): DecodeResultType;
+	}
+}

--- a/projects/ngx-advanced-img/src/public-api.ts
+++ b/projects/ngx-advanced-img/src/public-api.ts
@@ -3,5 +3,6 @@
  */
 
 export * from './lib/classes/bitmap';
+export * from './lib/classes/heic-converter';
 export * from './lib/directives/ngx-advanced-img-fallback.directive';
 export * from './lib/ngx-advanced-img.module';

--- a/projects/ngx-advanced-img/tsconfig.lib.json
+++ b/projects/ngx-advanced-img/tsconfig.lib.json
@@ -7,6 +7,9 @@
     "declarationMap": true,
     "inlineSources": true,
     "types": [],
+    "typeRoots": [
+      "src/lib/types/libheif.d.ts"
+    ],
     "lib": [
       "dom",
       "es2018"

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -133,14 +133,17 @@ export class AppComponent {
               ]);
 
               performance.mark('optimization_start');
-              bitmap.optimize(mimeType, +this.quality, +this.scale / 100, +this.maxDimension, {
-                sizeLimit: this.size ? +this.size : undefined,
-                minDimension: 100,
-                minScale: 0.025,
-                minQuality: 0.8,
-                mode: this.mode,
-                strict: !!this.strictMode
-              }).then((data: INgxAdvancedImgBitmapOptimization) => {
+              bitmap.optimize(
+                mimeType,
+                0.8,
+                1,
+                2900,
+                {
+                  minQuality: 0.8,
+                  minDimension: 2900,
+                  mode: 'prefer-size',
+                }
+              ).then((data: INgxAdvancedImgBitmapOptimization) => {
                 performance.mark('optimization_end');
                 performance.measure('Image Optimization', 'optimization_start', 'optimization_end');
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -145,17 +145,14 @@ export class AppComponent {
               ]);
 
               performance.mark('optimization_start');
-              bitmap.optimize(
-                mimeType,
-                0.8,
-                1,
-                2900,
-                {
-                  minQuality: 0.8,
-                  minDimension: 2900,
-                  mode: 'prefer-size',
-                }
-              ).then((data: INgxAdvancedImgBitmapOptimization) => {
+              bitmap.optimize(mimeType, +this.quality, +this.scale / 100, +this.maxDimension, {
+                sizeLimit: this.size ? +this.size : undefined,
+                minDimension: 100,
+                minScale: 0.025,
+                minQuality: 0.8,
+                mode: this.mode,
+                strict: !!this.strictMode
+              }).then((data: INgxAdvancedImgBitmapOptimization) => {
                 performance.mark('optimization_end');
                 performance.measure('Image Optimization', 'optimization_start', 'optimization_end');
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -111,7 +111,7 @@ export class AppComponent {
         if (file.type === 'image/heic') {
           const result = await this.workerConvert(
             file,
-            supportsWebp ? 'image/webp' : 'image/jpeg'
+            this.retainMimeType ? 'image/jpeg' : defaultMimeType
           );
 
           src = result.blob;

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -145,10 +145,10 @@ export class AppComponent {
                 performance.measure('Image Optimization', 'optimization_start', 'optimization_end');
 
                 // auto save this for the user
-                this.prettyLog(['[TEST] Saving URL:', data.objectURL, data.exifData, unOptimizedData.exifData]);
+                this.prettyLog(['[TEST] Saving URL:', data.blob, data.exifData, unOptimizedData.exifData]);
 
                 performance.mark('save_start');
-                bitmap.saveFile(`test_output_${AppComponent.getFileNameWithoutExtension(file)} _q - ${this.quality} _m - ${this.mode} _s - ${this.size} `, data.objectURL, mimeType);
+                bitmap.saveFile(`test_output_${AppComponent.getFileNameWithoutExtension(file)} _q - ${this.quality} _m - ${this.mode} _s - ${this.size} `, data.blob, mimeType);
                 performance.mark('save_end');
                 performance.measure('Image Saving', 'save_start', 'save_end');
 
@@ -163,8 +163,6 @@ export class AppComponent {
                 // reset performance
                 performance.clearMarks();
                 performance.clearMeasures();
-
-                URL.revokeObjectURL(data.objectURL);
 
                 // clean up the bitmap
                 bitmap.destroy();

--- a/src/app/app.worker.ts
+++ b/src/app/app.worker.ts
@@ -5,8 +5,9 @@ import { NgxAdvancedImgHeicConverter } from "../../projects/ngx-advanced-img/src
 
 addEventListener('message', async ({ data }) => {
   const file = data.file as File;
+  const mimeType = data.mimeType as string;
 
-  const result = await NgxAdvancedImgHeicConverter.convert(file);
+  const result = await NgxAdvancedImgHeicConverter.convert(file, mimeType);
 
   postMessage(result);
 });

--- a/src/app/app.worker.ts
+++ b/src/app/app.worker.ts
@@ -1,0 +1,16 @@
+/// <reference lib="webworker" />
+
+import { NgxAdvancedImgHeicConverter } from "../../projects/ngx-advanced-img/src/lib/classes/heic-converter";
+
+
+addEventListener('message', async ({ data }) => {
+  const response = `worker response to ${data}`;
+
+  const file = data.file as File;
+
+  const result = await NgxAdvancedImgHeicConverter.convert(file);
+
+  console.log(result);
+
+  postMessage(result);
+});

--- a/src/app/app.worker.ts
+++ b/src/app/app.worker.ts
@@ -4,13 +4,9 @@ import { NgxAdvancedImgHeicConverter } from "../../projects/ngx-advanced-img/src
 
 
 addEventListener('message', async ({ data }) => {
-  const response = `worker response to ${data}`;
-
   const file = data.file as File;
 
   const result = await NgxAdvancedImgHeicConverter.convert(file);
-
-  console.log(result);
 
   postMessage(result);
 });

--- a/tsconfig.worker.json
+++ b/tsconfig.worker.json
@@ -1,0 +1,15 @@
+/* To learn more about Typescript configuration file: https://www.typescriptlang.org/docs/handbook/tsconfig-json.html. */
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/worker",
+    "lib": [
+      "es2018",
+      "webworker"
+    ],
+    "types": []
+  },
+  "include": [
+    "src/**/*.worker.ts"
+  ]
+}


### PR DESCRIPTION
- Replaces use of the heic2any wrapper package with direct use of the libheif-js wasm version (https://www.npmjs.com/package/libheif-js). This improves performance compared to the pure Javascript version used by heic2any. Web Worker implementation will have to be handled in the app using this library, but `NgxAdvancedImgHeicConverter` has been added. This class is intended to be used within a web worker to convert a HEIC before passing the output to `NgxAdvancedImgBitmap`.

- `NgxAdvancedImgBitmap` will still convert HEIC images if they are loaded into the bitmap. Conversion will occur without a web worker. The `load` function was modified to load the image blob into a FileReader before beginning image load so that HEIC conversion is more seamless. 

- Replaced Data/Object URL use and output with Blobs to reduce memory strain

- Added web worker use to the sample application

